### PR TITLE
ci: Run eslint automatically for Pull Requests

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,0 +1,28 @@
+# This workflow will do a clean installation of node dependencies and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Node.js CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run lint

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prettier": "^2.7.1"
   },
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "lint": "npx eslint ."
   }
 }


### PR DESCRIPTION
Added a lint script to package.json. Execute it with `npm run lint`.
Created a GitHub actions which will run the eslint linter
automatically for PRs. The goal is to merge good, clean, readable
code.

Issue: None
Tested with: https://github.com/martimmatias/faithchatt/pull/1