### PR TITLE
jail: Stabilize basic jail features

### DIFF
--- a/events/guildMemberAdd.js
+++ b/events/guildMemberAdd.js
@@ -1,8 +1,42 @@
+const { PermissionsBitField } = require("discord.js");
+const { rolesId } = require("../utils/variables");
+const jailModel = require("../model/jailsystem.js");
+const jailSystem = require("../utils/jailSystem.js");
+const embedFactory = require("../utils/embedFactory.js");
+const perm = PermissionsBitField.Flags;
+
 module.exports = {
     once: false,
     name: "guildMemberAdd",
-    // eslint-disable-next-line no-unused-vars
-    async execute(_client) {
-        //
+    async execute(member) {
+        console.log(member.user.username + " joined the server");
+        // Give unverified role
+        const unverifiedRole = member.guild.roles.cache.get(rolesId.unverified);
+        member.roles.add(unverifiedRole).catch(console.error);
+
+        const jailData = await jailModel.findOne({ userId: member.user.id });
+
+        if (jailData) {
+            /**
+             * Get the jail channel
+             * @type {import("discord.js").TextChannel}
+             */
+            const jailChannel = member.guild.channels.cache.get(jailData.textChannel);
+
+            jailSystem.removeRoles(member.guild, member);
+            jailChannel.permissionOverwrites.set([
+                {
+                    id: member.user.id,
+                    allow: [perm.ViewChannel, perm.ReadMessageHistory, perm.SendMessages],
+                    deny: [perm.ManageChannels, perm.EmbedLinks, perm.AttachFiles, perm.CreatePublicThreads, perm.CreatePrivateThreads, perm.CreateInstantInvite, perm.SendMessagesInThreads, perm.ManageThreads, perm.ManageMessages, perm.UseExternalEmojis, perm.UseExternalStickers, perm.UseApplicationCommands, perm.ManageWebhooks, perm.ManageRoles, perm.SendTTSMessages],
+                },
+            ], "Previously jailed user rejoined the server.");
+            // Send embed in jailChannel
+            jailChannel.send({
+                embeds: [
+                    embedFactory.createJailEmbed(embedFactory.JailEmbedType.JailedUserRejoined, null, member, null, jailChannel),
+                ],
+            });
+        }
     },
 };

--- a/events/guildMemberRemove.js
+++ b/events/guildMemberRemove.js
@@ -1,7 +1,23 @@
+const jailModel = require("../model/jailsystem.js");
+const embedFactory = require("../utils/embedFactory.js");
+
 module.exports = {
     once: false,
     name: "guildMemberRemove",
-    async execute() {
-        //
+    async execute(member) {
+        console.log(member.user.username + " left the server");
+
+        const jailData = await jailModel.findOne({ userId: member.user.id });
+
+        if (jailData) {
+            const jailChannel = member.guild.channels.cache.get(jailData.textChannel);
+
+            // Send embed in jailChannel
+            jailChannel.send({
+                embeds: [
+                    embedFactory.createJailEmbed(embedFactory.JailEmbedType.JailedUserLeft, null, member, null, jailChannel),
+                ],
+            });
+        }
     },
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-const { Client } = require("discord.js");
+const { Client, GatewayIntentBits, Partials } = require("discord.js");
 
-const intentsLoad = ["DirectMessages", "Guilds", "GuildEmojisAndStickers", "GuildIntegrations", "GuildMessages", "GuildPresences", "GuildVoiceStates", "MessageContent"];
-const partialsLoad = ["User", "Channel", "GuildMember", "Message", "Reaction", "ThreadMember"];
+const intentsLoad = [GatewayIntentBits.DirectMessages, GatewayIntentBits.Guilds, GatewayIntentBits.GuildEmojisAndStickers, GatewayIntentBits.GuildIntegrations, GatewayIntentBits.GuildMessages, GatewayIntentBits.GuildPresences, GatewayIntentBits.GuildVoiceStates, GatewayIntentBits.MessageContent, GatewayIntentBits.GuildMembers];
+const partialsLoad = [Partials.User, Partials.Channel, Partials.GuildMember, Partials.Message, Partials.Reaction, Partials.ThreadMember];
 
 const client = new Client({ intents: intentsLoad, partials: partialsLoad });
 module.exports.client = client;

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
   },
   "homepage": "https://github.com/faithchatt/faithchatt#readme",
   "dependencies": {
+    "dedent": "^1.5.1",
     "discord.js": "^14.5.0",
     "dotenv": "^16.0.1",
+    "endent": "^2.1.0",
     "express": "^4.18.1",
     "fs": "^0.0.1-security",
     "moment": "^2.29.4",

--- a/utils/embedFactory.js
+++ b/utils/embedFactory.js
@@ -1,0 +1,128 @@
+const { EmbedBuilder } = require("discord.js");
+const dedent = require("dedent");
+
+const JailEmbedType = {
+    JailBeingSetup: 1,
+    JailedUserFacing: 2,
+    JailChannelIntroduction: 3,
+    JailedModLog: 4,
+    JailCreated: 5,
+    JailedUserLeft: 6,
+    JailedUserRejoined: 7,
+};
+
+exports.JailEmbedType = JailEmbedType;
+/**
+ * @param {JailEmbedType} embedType
+ * @param {import("discord.js").User} staffUser
+ * @param {import("discord.js").GuildMember} jailedMember
+ * @param {string} reason
+ * @param {import("discord.js").TextChannel} jailChannel
+ *
+ * @returns {import("discord.js").EmbedBuilder}
+ */
+exports.createJailEmbed = (embedType, staffUser, jailedMember, reason, jailChannel) => {
+    switch (embedType) {
+    case JailEmbedType.JailBeingSetup:
+        return new EmbedBuilder()
+            .setDescription(`🔒 **${jailedMember.user.tag}** has been jailed!\nPlease wait as the channel is being set up.`)
+            .setFooter({ text: `UID: ${jailedMember.user.id}` })
+            .setColor("#ff0000");
+
+    case JailEmbedType.JailedUserFacing:
+        return new EmbedBuilder()
+            .setTitle("You have been jailed!")
+            .setDescription(
+                dedent(
+                    `👤 **User:** \`${jailedMember.user.tag}\`
+                    🔒 **Reason:** \`${reason}\`
+                    
+                    You have been restricted access to all channels as of the moment. Leaving and rejoining the server to bypass the mute will result into a permanent sanction. ${jailChannel}`,
+                ))
+            .setFooter({ text: `UID: ${jailedMember.user.id}` })
+            .setColor("#ff0000");
+
+    case JailEmbedType.JailChannelIntroduction:
+        return new EmbedBuilder()
+            .setTitle("You have been jailed!")
+            .setDescription(
+                dedent(
+                    `👤 **User:** \`${jailedMember.user.tag}\`
+                    🔒 **Reason:** \`${reason}\`
+                    
+                    You have been restricted access to all channels as of the moment. Leaving and rejoining the server to bypass the mute will result into a permanent sanction.`,
+                ))
+            .setFooter({ text: `UID: ${jailedMember.user.id}` })
+            .setColor("#ff0000");
+
+    case JailEmbedType.JailedModLog:
+        return new EmbedBuilder()
+            .setDescription(
+                dedent(
+                    `👤 **User:** \`${jailedMember.user.tag}\`
+                    \`${jailedMember.user.id}\`
+                    🔒 **Reason:** \`${reason}\`
+                    
+                    👮‍♂️ **Moderator**: \`${staffUser.tag}\``,
+                ))
+            .setFooter({ text: `Moderator UID: ${staffUser.id}` })
+            .setColor("#ff0000");
+
+    case JailEmbedType.JailCreated:
+        return new EmbedBuilder()
+            .setDescription(
+                dedent(
+                    `🔒 **${jailedMember.user.tag}** has been jailed!
+                    
+                    ${jailChannel}`,
+                ),
+            )
+            .setFooter({ text: `UID: ${jailedMember.user.id}` })
+            .setColor("#ff0000");
+
+    case JailEmbedType.JailedUserLeft:
+        return new EmbedBuilder()
+            .setDescription(
+                dedent(
+                    `👤 **${jailedMember.user.tag}** left the server!
+                    
+                    They will be automatically jailed if they rejoin. Use the \`/closejail\` command to erase the database record and delete this channel.`,
+                ),
+            )
+            .setFooter({ text: `UID: ${jailedMember.user.id}` })
+            .setColor("#ff0000");
+
+    case JailEmbedType.JailedUserRejoined:
+        return new EmbedBuilder()
+            .setDescription(
+                dedent(
+                    `👤 **${jailedMember.user.tag}** rejoined the server!`,
+                ),
+            )
+            .setFooter({ text: `UID: ${jailedMember.user.id}` })
+            .setColor("#ff0000");
+
+    }
+};
+
+exports.createWarningEmbed = (description, footerText) => {
+    return new EmbedBuilder()
+        .setTitle("Warning")
+        .setDescription(description)
+        .setFooter({ text: footerText })
+        .setColor("#ffff00");
+};
+
+exports.createErrorEmbed = (description) => {
+    return new EmbedBuilder()
+        .setTitle("Error")
+        .setDescription(description)
+        .setColor("#ff0000");
+};
+
+exports.createSuccessEmbed = (description) => {
+    return new EmbedBuilder()
+        .setTitle("Success")
+        .setDescription(description)
+        .setColor("#00ff00");
+};

--- a/utils/jailSystem.js
+++ b/utils/jailSystem.js
@@ -1,0 +1,52 @@
+const { PermissionsBitField, ChannelType } = require("discord.js");
+const { parentId, rolesId } = require("./variables");
+const perm = PermissionsBitField.Flags;
+
+const jailSystem = {
+    /**
+    * Creates a jail channel for a member in a specific guild.
+    *
+    * @param {import("discord.js").Guild} guild - The guild on which the channel will be created.
+    * @param {import("discord.js").GuildMember} jailedMember - The member who will be jailed.
+    * @return {Promise<import("discord.js").TextChannel>} A promise that resolves when the channel is created.
+    */
+    createJailChannel(guild, jailedMember) {
+        const memberRole = guild.roles.cache.get(rolesId.member);
+        const mutedRole = guild.roles.cache.get(rolesId.muted);
+        const moderatorRole = guild.roles.cache.get(rolesId.moderator);
+        const everyone = guild.roles.cache.find(r => r.name === "@everyone");
+
+        return guild.channels.create({
+            name: `jail-${jailedMember.user.tag}`,
+            type: ChannelType.GuildText,
+            parent: parentId.jail,
+            topic: jailedMember.user.id,
+            permissionOverwrites: [
+                { id: jailedMember.user.id, allow: [perm.ViewChannel, perm.ReadMessageHistory, perm.SendMessages], deny: [perm.ManageChannels, perm.EmbedLinks, perm.AttachFiles, perm.CreatePublicThreads, perm.CreatePrivateThreads, perm.CreateInstantInvite, perm.SendMessagesInThreads, perm.ManageThreads, perm.ManageMessages, perm.UseExternalEmojis, perm.UseExternalStickers, perm.UseApplicationCommands, perm.ManageWebhooks, perm.ManageRoles, perm.SendTTSMessages] },
+                { id: mutedRole.id, deny: [perm.EmbedLinks, perm.AttachFiles] },
+                { id: memberRole.id, deny: [perm.ViewChannel] },
+                { id: moderatorRole.id, allow: [perm.ViewChannel, perm.SendMessages, perm.ReadMessageHistory] },
+                { id: everyone.id, deny: [perm.ViewChannel] },
+            ],
+        });
+    },
+
+    /**
+    * Removes roles from a guild member. Adds muted role.
+    *
+    * @param {import("discord.js").Guild} guild - The guild from which to remove roles.
+    * @param {import("discord.js").GuildMember} jailedMember - The member whose roles are to be removed.
+    * @return {Promise<void>} A promise that resolves when the roles are removed.
+    */
+    async removeRoles(guild, jailedMember) {
+        const unverifiedRole = guild.roles.cache.get(rolesId.unverified);
+        const mutedRole = guild.roles.cache.get(rolesId.muted);
+
+        const userRoles = jailedMember.roles.cache.filter(role => role.id !== mutedRole.id && role.id !== unverifiedRole.id && role.managed !== true);
+
+        await jailedMember.roles.add(mutedRole);
+        await jailedMember.roles.remove(userRoles);
+    },
+};
+
+module.exports = jailSystem;

--- a/variables/ErrorMessages.js
+++ b/variables/ErrorMessages.js
@@ -5,4 +5,5 @@ module.exports = {
     channelNotExist: "❌ | The corresponding channel does not exist.",
     channelWrong: "❌ | This user is not jailed in this specific channel.",
     notAllowedOutsideJail: "❌ | You are not allowed to execute outside the jail category.",
+    internalError: "❌ | An internal error has occurred.",
 };


### PR DESCRIPTION
Stabilized the basic jail commands.
Extracted embed creation to a factory-pattern like module called
embedFactory.
Took the opportunity and replaced strings in index.js with
constants while adding GatewayIntentBits.GuildMembers.
Users who leave jail, will be rejailed when joining (if never
unjailed). Banned users are to have their jail closed with
/closejail.

Issue: None